### PR TITLE
Adding compatibility with any theme

### DIFF
--- a/class-bb-header-footer.php
+++ b/class-bb-header-footer.php
@@ -29,7 +29,7 @@ class BB_Header_Footer {
 			$this->includes();
 			$this->load_textdomain();
 
-			// Load themes compatibility
+			// Load themes compatibility.
 			add_action( 'init', array( $this, 'themes_compat' ) );
 
 			// Scripts and styles.
@@ -48,17 +48,17 @@ class BB_Header_Footer {
 	 */
 	public function themes_compat() {
 		if ( 'genesis' == $this->template ) {
-			// Genesis framework theme compatibility
+			// Genesis framework theme compatibility.
 			require BBHF_DIR . 'themes/genesis/class-genesis-compat.php';
 		} elseif ( 'bb-theme' == $this->template || 'beaver-builder-theme' == $this->template ) {
-			// Beaver Builder Theme compatibility
+			// Beaver Builder Theme compatibility.
 			$this->template = 'beaver-builder-theme';
 			require BBHF_DIR . 'themes/bb-theme/class-bb-theme-compat.php';
 		} elseif ( 'generatepress' == $this->template ) {
-			// GeneratePress theme compatibility
+			// GeneratePress theme compatibility.
 			require BBHF_DIR . 'themes/generatepress/generatepress-compat.php';
 		} elseif ( ! current_theme_supports( 'bb-header-footer' ) ) {
-			// If the theme does not support this plugin, display admin notices
+			// If the theme does not support this plugin, display admin notices.
 			add_action( 'admin_notices', array( $this, 'unsupported_theme' ) );
 			add_action( 'network_admin_notices', array( $this, 'unsupported_theme' ) );
 		}

--- a/class-bb-header-footer.php
+++ b/class-bb-header-footer.php
@@ -29,20 +29,8 @@ class BB_Header_Footer {
 			$this->includes();
 			$this->load_textdomain();
 
-			if ( 'genesis' == $this->template ) {
-
-				require BBHF_DIR . 'themes/genesis/class-genesis-compat.php';
-			} elseif ( 'bb-theme' == $this->template || 'beaver-builder-theme' == $this->template ) {
-				$this->template = 'beaver-builder-theme';
-				require BBHF_DIR . 'themes/bb-theme/class-bb-theme-compat.php';
-			} elseif ( 'generatepress' == $this->template ) {
-
-				require BBHF_DIR . 'themes/generatepress/generatepress-compat.php';
-			} else {
-
-				add_action( 'admin_notices', array( $this, 'unsupported_theme' ) );
-				add_action( 'network_admin_notices', array( $this, 'unsupported_theme' ) );
-			}
+			// Load themes compatibility
+			add_action( 'init', array( $this, 'themes_compat' ) );
 
 			// Scripts and styles.
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
@@ -52,6 +40,27 @@ class BB_Header_Footer {
 
 			add_action( 'admin_notices', array( $this, 'bb_not_available' ) );
 			add_action( 'network_admin_notices', array( $this, 'bb_not_available' ) );
+		}
+	}
+
+	/**
+	 * Themes compatibility
+	 */
+	public function themes_compat() {
+		if ( 'genesis' == $this->template ) {
+			// Genesis framework theme compatibility
+			require BBHF_DIR . 'themes/genesis/class-genesis-compat.php';
+		} elseif ( 'bb-theme' == $this->template || 'beaver-builder-theme' == $this->template ) {
+			// Beaver Builder Theme compatibility
+			$this->template = 'beaver-builder-theme';
+			require BBHF_DIR . 'themes/bb-theme/class-bb-theme-compat.php';
+		} elseif ( 'generatepress' == $this->template ) {
+			// GeneratePress theme compatibility
+			require BBHF_DIR . 'themes/generatepress/generatepress-compat.php';
+		} elseif ( ! current_theme_supports( 'bb-header-footer' ) ) {
+			// If the theme does not support this plugin, display admin notices
+			add_action( 'admin_notices', array( $this, 'unsupported_theme' ) );
+			add_action( 'network_admin_notices', array( $this, 'unsupported_theme' ) );
 		}
 	}
 


### PR DESCRIPTION
If the theme declares support for this plugin via `add_theme_support( 'bb-header-footer' );` we don't have to display the incompatibility admin notices and let the theme code to do the compatibility job.

This closes the issue #24 